### PR TITLE
Avoid use of internal variable \g__tbl_row_int

### DIFF
--- a/colortbl/colortbl.dtx
+++ b/colortbl/colortbl.dtx
@@ -15,7 +15,7 @@
 %<driver>\ProvidesFile{colortbl.drv}
 % \fi
 %         \ProvidesFile{colortbl.dtx}
-          [2024/07/06 v1.0i Color table columns (DPC)]
+          [2024/07/08 v1.0j Color table columns (DPC)]
 %
 % \iffalse
 %<*driver>
@@ -1518,6 +1518,8 @@
 }
 %    \end{macrocode}
 %
+% \changes{v1.0j}{2024/07/08}
+%                {avoid use of internal variable \cs{g__tbl_row_int}}
 %    \begin{macrocode}
 \AtBeginDocument{
     \def\LT@@hline{%
@@ -1531,7 +1533,7 @@
             \multispan\LT@cols{%
               \tag_mc_begin:n{artifact}
               \CT@drsc@\leaders\hrule\@height\doublerulesep\hfill
-              \tag_mc_end: \int_gdecr:N \g__tbl_row_int 
+              \tag_mc_end: \tbl_gdecr_row_count:
             }\cr}%
         \fi
       \else
@@ -1543,13 +1545,13 @@
       \multispan\LT@cols
        {\tag_mc_begin:n{artifact}
         \CT@arc@\leaders\hrule\@height\arrayrulewidth\hfill
-        \tag_mc_end: \int_gdecr:N \g__tbl_row_int 
+        \tag_mc_end: \tbl_gdecr_row_count:
        }\cr
       \CT@LT@sep
       \multispan\LT@cols
        {\tag_mc_begin:n{artifact}
         \CT@arc@\leaders\hrule\@height\arrayrulewidth\hfill
-        \tag_mc_end: \int_gdecr:N \g__tbl_row_int 
+        \tag_mc_end: \tbl_gdecr_row_count:
        }\cr
       \noalign{\penalty\@M}%
       \LT@next}


### PR DESCRIPTION
Apply Ulrike Fischer's review suggestion in https://github.com/davidcarlisle/dpctex/pull/54#issuecomment-2211835018.