### PR TITLE
avoid changing the font loader in the typewriter package

### DIFF
--- a/typewriter/typewriter.lua
+++ b/typewriter/typewriter.lua
@@ -13,21 +13,21 @@ local format = string.format
 local insert = table.insert
 
 -- set the options
-local ttgreybolda       = tonumber(getmacro("ttgreybolda"))       or 0.6
-local ttgreyboldb       = tonumber(getmacro("ttgreyboldb"))       or 0.3
-local ttrotatebold      = tonumber(getmacro("ttrotatebold"))      or 12
-local ttdownbold        = tonumber(getmacro("ttdownbold"))        or 20000
-local ttrightbold       = tonumber(getmacro("ttrightbold"))       or 35000
-local ttoverprintbolda  = tonumber(getmacro("ttoverprintbolda"))  or 1
-local ttoverprintboldb  = tonumber(getmacro("ttoverprintboldb"))  or 1
-local ttoverprintboldc  = tonumber(getmacro("ttoverprintboldc"))  or 1
+local ttgreybolda       = tonumber(getmacro("ttgreybolda")       or 0.6)
+local ttgreyboldb       = tonumber(getmacro("ttgreyboldb")       or 0.3)
+local ttrotatebold      = tonumber(getmacro("ttrotatebold")      or 12)
+local ttdownbold        = tonumber(getmacro("ttdownbold")        or 20000)
+local ttrightbold       = tonumber(getmacro("ttrightbold")       or 35000)
+local ttoverprintbolda  = tonumber(getmacro("ttoverprintbolda")  or 1)
+local ttoverprintboldb  = tonumber(getmacro("ttoverprintboldb")  or 1)
+local ttoverprintboldc  = tonumber(getmacro("ttoverprintboldc")  or 1)
 
-local ttgreynormala     = tonumber(getmacro("ttgreynormala"))     or 0.3
-local ttgreynormalb     = tonumber(getmacro("ttgreynormalb"))     or 0.5
-local ttrotatenormal    = tonumber(getmacro("ttrotatenormal"))    or 10
-local ttrightnormal     = tonumber(getmacro("ttrightnormal"))     or 20000
-local ttdownnormal      = tonumber(getmacro("ttdownnormal"))      or 20000
-local ttoverprintnormal = tonumber(getmacro("ttoverprintnormal")) or 1
+local ttgreynormala     = tonumber(getmacro("ttgreynormala")     or 0.3)
+local ttgreynormalb     = tonumber(getmacro("ttgreynormalb")     or 0.5)
+local ttrotatenormal    = tonumber(getmacro("ttrotatenormal")    or 10)
+local ttrightnormal     = tonumber(getmacro("ttrightnormal")     or 20000)
+local ttdownnormal      = tonumber(getmacro("ttdownnormal")      or 20000)
+local ttoverprintnormal = tonumber(getmacro("ttoverprintnormal") or 1)
 
 local ttbasefont        = getmacro("ttgreybolda") or "cmuntt.otf"
 local ttfontsize        = getmacro("ttgreybolda") and sp(getmacro("ttgreybolda")) or sp("12pt")

--- a/typewriter/typewriter.lua
+++ b/typewriter/typewriter.lua
@@ -1,0 +1,144 @@
+-- Use local functions
+local getmacro = token.get_macro
+local sp = tex.sp
+local definefont = tex.definefont
+local define_font = luaotfload.define_font
+local getfont = font.getfont
+local nextid = font.nextid
+local setfont = font.setfont
+local random, rad = math.random, math.rad
+local cos, sin = math.cos, math.sin
+local pdfprint = pdf.print
+local format = string.format
+local insert = table.insert
+
+-- set the options
+local ttgreybolda       = tonumber(getmacro("ttgreybolda"))       or 0.6
+local ttgreyboldb       = tonumber(getmacro("ttgreyboldb"))       or 0.3
+local ttrotatebold      = tonumber(getmacro("ttrotatebold"))      or 12
+local ttdownbold        = tonumber(getmacro("ttdownbold"))        or 20000
+local ttrightbold       = tonumber(getmacro("ttrightbold"))       or 35000
+local ttoverprintbolda  = tonumber(getmacro("ttoverprintbolda"))  or 1
+local ttoverprintboldb  = tonumber(getmacro("ttoverprintboldb"))  or 1
+local ttoverprintboldc  = tonumber(getmacro("ttoverprintboldc"))  or 1
+
+local ttgreynormala     = tonumber(getmacro("ttgreynormala"))     or 0.3
+local ttgreynormalb     = tonumber(getmacro("ttgreynormalb"))     or 0.5
+local ttrotatenormal    = tonumber(getmacro("ttrotatenormal"))    or 10
+local ttrightnormal     = tonumber(getmacro("ttrightnormal"))     or 20000
+local ttdownnormal      = tonumber(getmacro("ttdownnormal"))      or 20000
+local ttoverprintnormal = tonumber(getmacro("ttoverprintnormal")) or 1
+
+local ttbasefont        = getmacro("ttgreybolda") or "cmuntt.otf"
+local ttfontsize        = getmacro("ttgreybolda") and sp(getmacro("ttgreybolda")) or sp("12pt")
+
+-- load the data of the base font. If the id is not passed to luaotfload.define_font
+-- as the third argument, the new id is the return value, otherwise
+-- the font data is returned.
+
+local base_id = define_font("file:" .. ttbasefont, ttfontsize)
+
+-- define \cmuntt as a font selction macro for the
+-- base font, and set the base font as the current 
+-- active font
+
+definefont("cmuntt", base_id)
+font.current(base_id)
+
+-- Some helper functions
+
+local function rotate(num)
+    local r = rad(0.1*num*random(-10,10))
+    pdfprint(format(" q %f %f %f %f 0 0 cm ",
+             cos(r), - sin(r), sin(r), cos(r)))
+end
+
+local function define_normal_tt_font(characters)
+    for j,v in pairs(characters) do
+        local greynormala = ttgreynormala*random()
+        local greynormalb = ttgreynormalb*random()
+        local cmd = {}
+        cmd = {
+            {'lua', function() rotate(ttrotatenormal) end},
+            {'pdf', ' ' .. greynormala .. ' g'},
+            {'push'},
+            {'right', random(-ttrightnormal, ttrightnormal)},
+            {'down', random(-ttdownnormal, ttdownnormal)},
+            {'char',j},
+            {'pop'},
+            {'lua', function() pdfprint(" Q ") end}
+        }
+            
+        if ttoverprintnormal == 1 then
+            insert(cmd, {'down', random(ttdownnormal, ttdownnormal)})
+            insert(cmd, {'pdf', ' ' .. greynormalb .. ' g'})
+            insert(cmd, {'char',j})
+            insert(cmd, {'pdf', ' 0 g'})
+        end
+        v.commands = cmd
+    end
+end
+
+local function define_bold_tt_font(characters)
+    for j, v in pairs(characters) do
+        local greybolda = ttgreybolda*random()
+        local greyboldb = ttgreyboldb*random()
+        local cmd = {}
+        cmd = {
+            {'lua', function() rotate(ttrotatebold) end},
+            {'pdf', ' ' .. format("%f", greybolda) .. ' g'},
+            {'push'},
+            {'right', random(-ttrightbold, ttrightbold)},
+            {'down', random(-ttdownbold, ttdownbold)},
+            {'char',j},
+            {'pop'},
+            {'lua', function() pdfprint(" Q ") end}
+        }
+        
+        if ttoverprintbolda == 1 then
+            insert(cmd, {'push'})
+            insert(cmd, {'right', random(-ttrightbold, ttrightbold)})
+            insert(cmd, {'down', random(-ttdownbold, ttdownbold)})
+            insert(cmd, {'char',j})
+            insert(cmd, {'pop'})
+        end
+        
+        if ttoverprintboldb == 1 then
+            insert(cmd, {'push'})
+            insert(cmd, {'right', random(-ttrightbold, ttrightbold)})
+            insert(cmd, {'down', random(-ttdownbold, ttdownbold)})
+            insert(cmd, {'char',j})
+            insert(cmd, {'pop'})
+            insert(cmd, {'push'})
+            insert(cmd, {'down', random(-ttdownbold, ttdownbold)})
+            insert(cmd, {'pdf', ' ' .. format("%f", greyboldb) .. ' g'})
+            insert(cmd, {'char',j})
+            insert(cmd, {'pdf', ' 0 g'})
+            insert(cmd, {'pop'})
+        end
+        v.commands = cmd
+    end
+end
+
+-- Now the main function
+
+local function define_tt_font(name, csname, size, bold)
+    local f = getfont(base_id)
+    f.name = name
+    f.type = 'virtual'
+    f.fonts = {{ name = "file:"..ttbasefont, size = size}}
+    if bold then
+        define_bold_tt_font(f.characters)
+    else
+        define_normal_tt_font(f.characters)
+    end
+    local id = nextid(true)
+    setfont(id, f)
+    definefont(csname, id)
+end
+
+define_tt_font("cmtt10x", "myfont", sp('12pt'), false)
+define_tt_font("cmtt10x", "myfonts", sp('9pt'), false)
+define_tt_font("cmtt10bx", "mybfont", sp('12pt'), true)
+define_tt_font("cmtt10bx", "mybfonts", sp('9pt'), true)
+

--- a/typewriter/typewriter.sty
+++ b/typewriter/typewriter.sty
@@ -3,124 +3,12 @@
 % Licence: LPPL
 % See http://tex.stackexchange.com/questions/344214/use-latex-to-simulate-old-typewriter-written-texts
 
-
 \ProvidesPackage{typewriter}[2018-02-16 v1.2 typewriter package]
 
 \ifx\directlua\@undefined
 \endinput\PackageError{typewriter}{LuaLaTeX required for this package}\@ehc\fi
 
-\providecommand\ttgreybolda{0.6}
-\providecommand\ttgreyboldb{0.3}
-\providecommand\ttrotatebold{12}
-\providecommand\ttdownbold{20000}
-\providecommand\ttrightbold{35000}
-\providecommand\ttoverprintbolda{1}
-\providecommand\ttoverprintboldb{1}
-\providecommand\ttoverprintboldc{1}
-
-\providecommand\ttgreynormala{0.3}
-\providecommand\ttgreynormalb{0.5}
-\providecommand\ttrotatenormal{10}
-\providecommand\ttrightnormal{20000}
-\providecommand\ttdownnormal{20000}
-\providecommand\ttoverprintnormal{1}
-
-\providecommand\ttbasefont{cmuntt.otf}
-\providecommand\ttfontsize{12pt}
-
-% luaotfload exlicitly loaded for latex formats before 2017/01/01
-\usepackage{luaotfload}
-
-% load cmuntt here not from lua (for everyone except me, it seems)
-% braces allow for spaces in file names.
-\font\cmuntt = {file:\ttbasefont}\space at \ttfontsize\relax \cmuntt
-\edef\cmunttid{\fontid\cmuntt}
-
-
-\expandafter\let\expandafter\%\csname @percentchar\endcsname
-\directlua {
- local cbl=luatexbase.callback_descriptions('define_font')
-% print('\string\n======' .. cbl[1] .. '===\string\n')
-original_fontloader=luatexbase.remove_from_callback('define_font',cbl[1])
-luatexbase.add_to_callback('define_font',
-function(name,size,i)
-  if (name=='cmtt10x' or name=='cmtt10bx') then
-% this works in my dev version but for older setups
-% make sure cmuntt.otf has been loaded before we mess
-% up the font loader.
-%  f = original_fontloader('cmuntt.otf',size)
-  f = font.getfont(\cmunttid)
-              f.name = 'cmtt10x'
-              f.type = 'virtual'
-              f.fonts = {{ name = 'file:\ttbasefont', size = size}}
-for j,v in pairs(f.characters) do
-  local greynormala = \ttgreynormala*math.random()
-  local greynormalb = \ttgreynormalb*math.random()
-  local greybolda = \ttgreybolda*math.random()
-  local greyboldb = \ttgreyboldb*math.random()
-if name == 'cmtt10bx' then
-                       v.commands = {
-{'lua','
-  r1 = math.rad(0.1*\ttrotatebold*math.random(-10,10))
-pdf.print
-(string.format(" q \%f \%f \%f \%f 0 0 cm ",
-math.cos(r1), - math.sin(r1), math.sin(r1), math.cos(r1)
-))'},
-                           {'special','pdf: ' .. string.format("\%f",greybolda) .. ' g'},
-{'push'},
-{'right', math.random(-\ttrightbold,\ttrightbold)},
-{'down', math.random(-\ttdownbold,\ttdownbold)},
-                           {'char',j},
-{'pop'},
-{'lua','pdf.print(" Q ")'}\ifnum\ttoverprintbolda=1,
-{'push'},
-{'right', math.random(-\ttrightbold,\ttrightbold)},
-{'down', math.random(-\ttdownbold,\ttdownbold)},
-                           {'char',j},
-{'pop'}\fi\ifnum\ttoverprintboldb=1,
-{'push'},
-{'right', math.random(-\ttrightbold,\ttrightbold)},
-{'down', math.random(-\ttdownbold,\ttdownbold)},
-                           {'char',j},
-{'pop'}\fi\ifnum\ttoverprintboldb=1,
-{'push'},
-{'down', math.random(-\ttdownbold,\ttdownbold)},
-                           {'special','pdf: ' .. string.format("\%f",greyboldb) .. ' g'},
-                           {'char',j},
-                           {'special','pdf: 0 g'},
-{'pop'}
-\fi
-                         }
-else
-                       v.commands = {
-{'lua','
-  r1 = math.rad(0.1*\ttrotatenormal*math.random(-10,10))
-pdf.print
-(string.format(" q \%f \%f \%f \%f 0 0 cm ",
-math.cos(r1), math.sin(r1), - math.sin(r1), math.cos(r1)
-))'},
-                           {'special','pdf: ' .. greynormala .. ' g'},
-{'push'},
-{'right', math.random(-\ttrightnormal,\ttrightnormal)},
-{'down', math.random(-\ttdownnormal,\ttdownnormal)},
-                           {'char',j},
-{'pop'},
-{'lua','pdf.print(" Q ")'}\ifnum\ttoverprintnormal=1,
-{'down', math.random(-\ttdownnormal,\ttdownnormal)},
-                           {'special','pdf: ' .. greynormalb .. ' g'},
-                           {'char',j},
-                           {'special','pdf: 0 g'}
-\fi
-                         }
-end
-end
-return f
-else
-return original_fontloader(name,size,i)
-end
-end,
-'define font')
-}
+\directlua{require('typewriter.lua')}
 
 {\count0=0
 \loop
@@ -138,10 +26,7 @@ end,
 \AtBeginDocument{%
 \sbox0{$\relax$}%
 
-\font\myfont= cmtt10x at 12pt \myfont
-\font\myfonts= cmtt10x at 9pt
-\font\mybfont= cmtt10bx at 12pt
-\font\mybfonts= cmtt10bx at 9pt
+\myfont
 
 %if it is a monospace font force monospace space
 \ifdim\fontcharwd\myfont`.=\fontcharwd\myfont`M


### PR DESCRIPTION
The main point of this commit is
to avoid changing luaotfloads' fontloader,
by using luaotfload.define_font directly.

In addition it moves the lua code to a separate
file, and somewhat abstract the code.

The only incompatibility is that with the current
code e.g. `\ttoverprintboldb` can be a count register,
or a char token. I did not think this is a problem,
but if it is I can add a test for that situation