### PR TITLE
[typewriter]  add support for nfss fonts

### DIFF
--- a/typewriter/typewriter.lua
+++ b/typewriter/typewriter.lua
@@ -155,3 +155,25 @@ define_tt_font(base_id, ttbasefont, "cmtt10bx", "mybfont", ttfontsize, true)
 define_tt_font(base_math_id, ttmathfont, "cmtt10mbx", "mymbfont", ttfontsize, true)
 define_tt_font(base_math_id, ttmathfont, "cmtt10mbx", "mymbfonts", floor(0.75*ttfontsize), true)
 
+local patch_enabled = false
+local fonts_patched = { }
+luatexbase.add_to_callback("luaotfload.patch_font", function(data)
+    local fontname = data.fontname
+    if not (patch_enabled or fonts_patched[data.fontname]) then
+        return true
+    end
+    if not fonts_patched[fontname] then
+        fonts_patched[fontname] = true
+    end
+    define_normal_tt_font(data.characters)
+end, "patch tt fonts")
+
+local function_table = lua.get_functions_table()
+local luafnalloc = luatexbase.new_luafunction('patchttfonts')
+token.set_lua('patchttfonts', luafnalloc)
+function_table[luafnalloc] = function() patch_enabled = true end
+
+local luafnalloc = luatexbase.new_luafunction('dontpatchttfonts')
+token.set_lua('dontpatchttfonts', luafnalloc)
+function_table[luafnalloc] = function() patch_enabled = false end
+

--- a/typewriter/typewriter.lua
+++ b/typewriter/typewriter.lua
@@ -157,21 +157,26 @@ define_tt_font(base_math_id, ttmathfont, "cmtt10mbx", "mymbfonts", floor(0.75*tt
 
 local patch_enabled = false
 local fonts_patched = { }
-luatexbase.add_to_callback("luaotfload.patch_font", function(data)
-    local fontname = data.fontname
-    if not (patch_enabled or fonts_patched[data.fontname]) then
-        return true
-    end
-    if not fonts_patched[fontname] then
-        fonts_patched[fontname] = true
-    end
-    define_normal_tt_font(data.characters)
-end, "patch tt fonts")
-
 local function_table = lua.get_functions_table()
+local function enable_patch()
+    local luafnalloc = token.create('patchttfonts').index
+    function_table[luafnalloc] = function() patch_enabled = true end
+    patch_enabled = true
+    luatexbase.add_to_callback("luaotfload.patch_font", function(data)
+        local fontname = data.fontname
+        if not (patch_enabled or fonts_patched[data.fontname]) then
+            return true
+        end
+        if not fonts_patched[fontname] then
+            fonts_patched[fontname] = true
+        end
+        define_normal_tt_font(data.characters)
+    end, "patch tt fonts")
+end
+
 local luafnalloc = luatexbase.new_luafunction('patchttfonts')
 token.set_lua('patchttfonts', luafnalloc)
-function_table[luafnalloc] = function() patch_enabled = true end
+function_table[luafnalloc] = enable_patch
 
 local luafnalloc = luatexbase.new_luafunction('dontpatchttfonts')
 token.set_lua('dontpatchttfonts', luafnalloc)


### PR DESCRIPTION
This is just an experiment so not for the upcoming realease. 
I'm really bad at user interface so feel free to change it
if you have a better idea.

This adds a function to the patch_font
callback that will patch any font loaded
when patching is allowed (using the \patchttfont
macro), or if it has a name of a font patched before (to allow different sizes).

It currently won't really work since \select font
is redefined, but it does not interfer. Maybe a package option to not patch thing should be added to allow this functionality.

Here is an example:
```tex
\documentclass{article}

\usepackage{typewriter}

\let\Gamma\relax\let\Delta\relax
\let\Theta\relax\let\Lambda\relax
\let\Xi\relax\let\Pi\relax
\let\Sigma\relax\let\Phi\relax
\let\Upsilon\relax\let\Psi\relax
\let\Omega\relax\let\mathdollar\relax

\usepackage{fontspec}

\begin{document}

\expandafter\let\expandafter\selectfont
    \csname selectfont \endcsname
    
\patchttfonts
\setmainfont{NewCM10-Regular}
\dontpatchttfonts

\newfontfamily\foo{NewCM10-Book}

Test \fontsize{40pt}{50pt}\selectfont Test

\foo Test
\end{document}
```
![image](https://github.com/user-attachments/assets/61e498be-c9d5-4db1-a317-1d53f2e8a78a)

* If mono-spaced space is also desired, we can 
   add something like
    ```tex
    \ifdim\fontcharwd\font`.=\fontcharwd\font`M
      \fontdimen6\font=\fontcharwd\font`x
      \fontdimen2\font=\fontdimen6\font
      \fontdimen3\font=\z@
      \fontdimen4\font=\z@
      \fontdimen7\font=\fontdimen6\font
    \fi
    ```
    to the `selectfont` hook.
* The rotation should probably be in proportion
    to the character width if this method is used. 