### PR TITLE
avoid error with hhline + tagging code, tagging issue 66

### DIFF
--- a/colortbl/colortbl.dtx
+++ b/colortbl/colortbl.dtx
@@ -1445,10 +1445,10 @@
   \vskip\doublerulesep
   \hrule \@height \arrayrulewidth \@width #2}}}
 %    \end{macrocode}
-%
+%\changes{v1.0l}{2026-05-01}{Decrease row count, for tagging-project issue 66}
 %    \begin{macrocode}
 \def\HH@loop{%
-  \ifx\@tempb`\def\next##1{\the\toks@\cr}\else\let\next\HH@let
+  \ifx\@tempb`\def\next##1{\the\toks@\csname tbl_gdecr_row_count:\endcsname\cr}\else\let\next\HH@let
   \ifx\@tempb|\if@tempswa
           \ifx\CT@drsc@\relax
            \HH@add{\hskip\doublerulesep}%

--- a/colortbl/colortbl.dtx
+++ b/colortbl/colortbl.dtx
@@ -1166,7 +1166,7 @@
   \UseTaggingSocket{tbl/leaders/begin}%
   {\CT@arc@\leaders\hrule\@height\arrayrulewidth\hfill}%
   \UseTaggingSocket{tbl/leaders/end}%
-  \csname tbl_gdecr_row_count:\endcsname    
+  \CT@tbl@gdecr@row@count
   \cr
   \noalign{\vskip-\arrayrulewidth}}
 %    \end{macrocode}
@@ -1448,7 +1448,7 @@
 %\changes{v1.0l}{2026-05-01}{Decrease row count, for tagging-project issue 66}
 %    \begin{macrocode}
 \def\HH@loop{%
-  \ifx\@tempb`\def\next##1{\the\toks@\csname tbl_gdecr_row_count:\endcsname\cr}\else\let\next\HH@let
+  \ifx\@tempb`\def\next##1{\the\toks@\CT@tbl@gdecr@row@count\cr}\else\let\next\HH@let
   \ifx\@tempb|\if@tempswa
           \ifx\CT@drsc@\relax
            \HH@add{\hskip\doublerulesep}%
@@ -1524,6 +1524,10 @@
 \ExplSyntaxOn
 %    \end{macrocode}
 %
+% A copy of \cs{tbl_gdecr_row_count:}
+%    \begin{macrocode}
+\let\CT@tbl@gdecr@row@count\tbl_gdecr_row_count:
+%    \end{macrocode}
 % Stub tag support if tagging has not been enabled.
 %    \begin{macrocode}
 \cs_if_exist:NF\tag_mc_begin:n{

--- a/colortbl/testfiles/tagging66.luatex.tlg
+++ b/colortbl/testfiles/tagging66.luatex.tlg
@@ -1,0 +1,59 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- tagging66.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.008"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>a
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- tagging66.xml (end) -----------
+============================================================
+[1
+]<<latex-list-css.html>><<latex-align-css.html>> (tagging66.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~11 structure objects
+(tagpdf)             with ~5 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/colortbl/testfiles/tagging66.lvt
+++ b/colortbl/testfiles/tagging66.lvt
@@ -1,0 +1,15 @@
+% https://github.com/latex3/tagging-project/issues/1331
+\DocumentMetadata{lang=en,tagging=on}
+\input{regression-test}  
+\documentclass{article}
+\usepackage{colortbl}
+\usepackage{hhline}
+\begin{document}
+\START
+\begin{tabular}{l}
+\hhline{=}
+a
+\end{tabular}
+
+\SHOWPDFTAGS
+\end{document}

--- a/colortbl/testfiles/tagging66.tlg
+++ b/colortbl/testfiles/tagging66.tlg
@@ -1,0 +1,61 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- tagging66.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>a
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- tagging66.xml (end) -----------
+============================================================
+[1
+]<<latex-list-css.html>><<latex-align-css.html>> (tagging66.aux)
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~10 structure objects
+(tagpdf)             with ~5 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root

--- a/colortbl/testfiles/tagging66.xetex.tlg
+++ b/colortbl/testfiles/tagging66.xetex.tlg
@@ -1,0 +1,61 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: Show PDF Tags
+============================================================
+-------- tagging66.xml (start) ---------
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>a
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>
+-------- tagging66.xml (end) -----------
+============================================================
+Package tagpdf Info: Finalizing the tagging structure:
+(tagpdf)             Writing out ~10 structure objects
+(tagpdf)             with ~5 'MC' leaf nodes.
+(tagpdf)             Be patient if there are lots of objects!
+Package tagpdf Info: writing ParentTree
+Package tagpdf Info: writing IDTree
+Package tagpdf Info: writing RoleMap
+Package tagpdf Info: writing ClassMap
+Package tagpdf Info: writing NameSpaces
+Package tagpdf Info: writing StructElems
+Package tagpdf Info: writing Root
+[1
+] (tagging66.aux)


### PR DESCRIPTION
This avoids the error from https://github.com/latex3/tagging-project/issues/66 if colortbl is used, but doesn't adjust the tagging of the rules. With luatex they should be fine, but with pdflatex they are not correctly marked as artifact.